### PR TITLE
Oxygen 4 compatibility

### DIFF
--- a/commands/class-oxygensignshortcode.php
+++ b/commands/class-oxygensignshortcode.php
@@ -26,40 +26,38 @@ class OxygenSignShortcode extends WP_CLI_Command {
 		global $oxygen_signature;
 		$oxygen_signature = new OXYGEN_VSB_Signature();
 	
-		$posts = get_posts(
-			[
-				'post_type' => $args,
-				'numberposts' => -1,
-				'orderby' => 'ID',
-				'order' => 'ASC',
-				'meta_key' => 'ct_builder_shortcodes',
-			]
-		);
-	
-		WP_CLI::line(sprintf("Found %d post(s)", count($posts)));
-	
-		foreach ($posts as $post) {
-			$shortcodes = get_post_meta($post->ID, 'ct_builder_shortcodes', true);
-	
-			if (!$shortcodes) {
-				WP_CLI::warning("No shortcodes found on post of type \"{$post->post_type}\" with ID = {$post->ID}", false);
-			} else {
-				$not_registered_shortcodes = oxygen_has_not_registered_shortcodes($shortcodes);
-				if ($not_registered_shortcodes) {
-					$message = 'Inactive Shortcodes Present: "' . implode(', ', $not_registered_shortcodes) . "\" on post type \"{$post->post_type}\" with ID = {$post->ID} - Activate Add-Ons Before Re-Signing.";
-					WP_CLI::warning($message, false);
-				} else {
-					WP_CLI::line("Signing shortcodes on post type \"{$post->post_type}\" with ID = {$post->ID}");
-	
-					// parse without verifying signature, as these might not have any signature
-					$shortcodes = parse_shortcodes($shortcodes, false, false);
-	
-					//save again and re-sign in the process
-					$shortcodes = parse_components_tree($shortcodes['content']);
-	
-					update_post_meta($post->ID, 'ct_builder_shortcodes', $shortcodes);
-				}
+		foreach ( $args as $type ) {
+			$pages = get_posts(
+				array(
+					'post_type' => array( $type ),
+					'numberposts' => -1,
+					'orderby' => 'ID',
+					'order' => 'ASC',
+					'meta_key' => 'ct_builder_shortcodes',
+				)
+			);
+
+			if ( !is_array( $pages ) or count( $pages ) == 0 ) {
+				WP_CLI::warning( "No posts found of type $type" );
 			}
+
+			$page_ids = array_map( function ( $page ) {
+				return $page->ID;
+			}, $pages );
+	
+			WP_CLI::line( sprintf( "Found %d post(s) of type %s", count( $page_ids ), $type ) );
+	
+			$_REQUEST['page_ids'] = $page_ids;
+			do {
+				$response = oxygen_vsb_sign_shortcodes( $type );
+				foreach ( $response['messages'] as $message ) {
+					WP_CLI::line( $message );
+				}
+				if ( ! array_key_exists( 'index', $response ) ) {
+					break;
+				}
+				$_REQUEST['index'] = $response['index'];
+			} while (true);
 		}
 	}
 }

--- a/commands/class-oxygensignshortcode.php
+++ b/commands/class-oxygensignshortcode.php
@@ -12,12 +12,12 @@ class OxygenSignShortcode extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <post-type>...
-	 * : Specify the post types to sign the oxygen's shorcode.
+	 * : Specify the post types to sign the oxygen's shortcode.
 	 * 
 	 * ## EXAMPLES
 	 * 
-	 *    wp artifact oxygen-builder sign-shortcode page
-	 *    wp artifact oxygen-builder sign-shortcode page ct_template
+	 *    wp oxygen sign-shortcode page
+	 *    wp oxygen sign-shortcode page ct_template
 	 *
 	 * @when wp_loaded
 	 * @subcommand sign-shortcode


### PR DESCRIPTION
Contrary to what I said in #1, currently signing shortcodes doesn't work under Oxygen 4.

This update uses the native Oxygen shortcode signing process and works under Oxygen 4. It should still works under 3.9 also.