### PR TITLE
🐛 Oxygen meta key changed in 4.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 5. Activate Plugin in WP Backend
 
 ## Tested Oxygen versions
+
+- 4.8.3
+
+### Versions before 1.2.0
 - 4
 - 3.9
 - 3.8

--- a/commands/class-oxygenregeneratecsscache.php
+++ b/commands/class-oxygenregeneratecsscache.php
@@ -52,12 +52,12 @@ class OxygenRegenerateCssCache extends WP_CLI_Command {
       'meta_query' => [
         'relation' => 'OR',
         [
-          'key'     => 'ct_builder_shortcodes',
+          'key'     => '_ct_builder_shortcodes',
           'value'   => '',
           'compare' => '!=',
         ],
         [
-          'key'     => 'ct_builder_json',
+          'key'     => '_ct_builder_json',
           'value'   => '',
           'compare' => '!=',
         ],

--- a/commands/class-oxygensignshortcode.php
+++ b/commands/class-oxygensignshortcode.php
@@ -33,7 +33,7 @@ class OxygenSignShortcode extends WP_CLI_Command {
 					'numberposts' => -1,
 					'orderby' => 'ID',
 					'order' => 'ASC',
-					'meta_key' => 'ct_builder_shortcodes',
+					'meta_key' => '_ct_builder_shortcodes',
 				)
 			);
 


### PR DESCRIPTION
Since 4.8.3 all Oxygen meta keys have been prefixed by a _. This PR ensure that the CLI command works for new Oxygen versions but won't work for versions below 4.8.3.

Users with Oxygen not updated have to stick with version 1.2.0 of this plugin.